### PR TITLE
Fix incorrect comparison. CRSS for twinning (and therefore twin shear…

### DIFF
--- a/src/materialModels/crystalPlasticity/MaterialModels/RateIndependentMPTwinModel/calculatePlasticity.cc
+++ b/src/materialModels/crystalPlasticity/MaterialModels/RateIndependentMPTwinModel/calculatePlasticity.cc
@@ -188,7 +188,7 @@ crystalPlasticity<dim>::calculatePlasticity(unsigned int cellID,
     {
       s_alpha_t[i] = s_alpha_conv[cellID][quadPtID][i];
       if (i >= n_slip_systemsWOtwin
-        && ttwinvf1[i - n_slip_systemsWOtwin] >= this->userInputs_cp.MPtwinLowerThresholdFraction1)
+        && ttwinvf1[i - n_slip_systemsWOtwin] < this->userInputs_cp.MPtwinLowerThresholdFraction1)
         {
           // TODO: determine if this is working correctly, or whether it needs to
           // be done differently.

--- a/src/materialModels/crystalPlasticity/calculatePlasticity.cc
+++ b/src/materialModels/crystalPlasticity/calculatePlasticity.cc
@@ -188,7 +188,7 @@ crystalPlasticity<dim>::calculatePlasticity(unsigned int cellID,
     {
       s_alpha_t[i] = s_alpha_conv[cellID][quadPtID][i];
       if (i >= n_slip_systemsWOtwin
-        && ttwinvf1[i - n_slip_systemsWOtwin] >= this->userInputs_cp.MPtwinLowerThresholdFraction1)
+        && ttwinvf1[i - n_slip_systemsWOtwin] < this->userInputs_cp.MPtwinLowerThresholdFraction1)
         {
           // TODO: determine if this is working correctly, or whether it needs to
           // be done differently.


### PR DESCRIPTION
…) should be effectively infinite outside the twin, since twin nucleation/growth is handled by phase field